### PR TITLE
fix: kick off semantic release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,7 @@
+branch: main
+branches: ["main"]
+plugins: [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github",
+]

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
-branch: main
-branches: ["main"]
+branch: master
+branches: ["master"]
 plugins: [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
The [semantic release failed](https://github.com/department-of-veterans-affairs/vets-api-pghero/issues/6) due to the commit syntax not being correct. See [semantic release docs](https://github.com/semantic-release/semantic-release). This adds the .releaserc file