### PR TITLE
fix deprecated set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set output
         id: set-environments
         run: |
-          echo "::set-output name=environments::${{ env.environments }}"
+          echo "environments=${{ env.environments }}" >> $GITHUB_OUTPUT
   release:
     needs: [prepare-values]
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Capture argo image versions
         id: componentVersions
         run: |
-          echo "::set-output name=config::$(jq -c .components versions.json)"
+          echo "config=$(jq -c .components versions.json)" >> $GITHUB_OUTPUT
       - name: Upload versions file
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The [Github set-output command is being deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in an upcoming version.


https://app.zenhub.com/workspaces/platform-tech-team-1-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/50727