### PR TITLE
chore: bump to latest version

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "components": [
     {
       "name": "pghero",
-      "version": "v3.4.0",
+      "version": "v3.6.0",
       "repo": "ankane/pghero"
     }
   ]


### PR DESCRIPTION
Bumps to the [latest version ](https://github.com/department-of-veterans-affairs/vets-api-pghero/pull/17)of pghero. We noticed some growth stats weren't being reported and this may fix the issue, but either way we should always want to run the latest version.