### PR TITLE
chore: update deprecated action

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "config=$(jq -c .components versions.json)" >> $GITHUB_OUTPUT
       - name: Upload versions file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: versions
           path: versions.json


### PR DESCRIPTION
Update deprecated action causing the mirror to fail