### PR TITLE
chore: Use noreply for va-vsp-bot email

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,6 @@ jobs:
           add: '*'
           cwd: vsp-infra-application-manifests/apps/pghero
           author_name: va-vsp-bot
-          author_email: devops@va.gov
+          author_email: 70344339+va-vsp-bot@users.noreply.github.com
           message: 'auto update pghero ${{ needs.prepare-values.outputs.environments }} images'
 


### PR DESCRIPTION
- Do not use @va.gov email address
- Instead use a `noreply` email address
- Per https://github.com/orgs/department-of-veterans-affairs/discussions/13
  - This technically only applies to public repos, but consistency across all repos is appreciated